### PR TITLE
[로그인] > Session redis 반영

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    // 레디스 적용
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     // 레디스 적용
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // spring session 을 활용해서 레디스에 Session 저장
+    implementation 'org.springframework.session:spring-session-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/toy/RedisApplication.java
+++ b/src/main/java/toy/RedisApplication.java
@@ -1,0 +1,27 @@
+package toy;
+
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class RedisApplication {
+	public static void redisSimpleTest() {
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory();
+		connectionFactory.afterPropertiesSet();
+
+		RedisTemplate<String, String> template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+		template.setDefaultSerializer(StringRedisSerializer.UTF_8);
+		template.afterPropertiesSet();
+
+		template.opsForValue().set("foo", "test");
+		log.info("Value at foo : {}", template.opsForValue().getAndDelete("foo"));
+
+		connectionFactory.destroy();
+
+	}
+
+}

--- a/src/main/java/toy/WebConfig.java
+++ b/src/main/java/toy/WebConfig.java
@@ -6,15 +6,15 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import toy.login.cookie.interceptor.LoginCookieCheckInterceptor;
 import toy.login.session.interceptor.LoginSessionCheckInterceptor;
-import toy.login.session.repository.SessionRepository;
+import toy.login.session.repository.LoginSessionRepository;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-	private final SessionRepository sessionRepository;
+	private final LoginSessionRepository loginSessionRepository;
 
-	public WebConfig(SessionRepository sessionRepository) {
-		this.sessionRepository = sessionRepository;
+	public WebConfig(LoginSessionRepository loginSessionRepository) {
+		this.loginSessionRepository = loginSessionRepository;
 	}
 
 	@Override
@@ -26,7 +26,7 @@ public class WebConfig implements WebMvcConfigurer {
 				"/css/**", "/*.ico", "/error"
 			);
 
-		registry.addInterceptor(new LoginSessionCheckInterceptor(sessionRepository))
+		registry.addInterceptor(new LoginSessionCheckInterceptor(loginSessionRepository))
 			.addPathPatterns("/session/**")
 			.excludePathPatterns(
 				"/session/login", "/session/login/logout",

--- a/src/main/java/toy/login/LoginApplication.java
+++ b/src/main/java/toy/login/LoginApplication.java
@@ -14,6 +14,7 @@ public class LoginApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(LoginApplication.class, args);
+		// RedisApplication.redisSimpleTest();
 	}
 
 }

--- a/src/main/java/toy/login/LoginApplication.java
+++ b/src/main/java/toy/login/LoginApplication.java
@@ -2,14 +2,11 @@ package toy.login;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-
-import toy.WebConfig;
 
 @SpringBootApplication
 @EnableJpaAuditing
-@Import(WebConfig.class)
+// @Import(WebConfig.class)
 public class LoginApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/toy/login/commons/config/RedisConfig.java
+++ b/src/main/java/toy/login/commons/config/RedisConfig.java
@@ -1,9 +1,5 @@
 package toy.login.commons.config;
 
-import org.springframework.context.annotation.Bean;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-
 // @EnableRedisRepositories
 // @Configuration
 public class RedisConfig {
@@ -12,8 +8,8 @@ public class RedisConfig {
 	 * 별도로 선언을 해서 redisConnectionFactory 를 변경할 수 있다.
 	 * 하지만 Spring boot 를 사용하면 별도로 지정하지 않아도 autoConfiguration 에 의해서 등록된다.
 	 */
-	@Bean
-	public RedisConnectionFactory redisConnectionFactory() {
-		return new LettuceConnectionFactory();
-	}
+	// @Bean
+	// public RedisConnectionFactory redisConnectionFactory() {
+	// 	return new LettuceConnectionFactory();
+	// }
 }

--- a/src/main/java/toy/login/commons/config/RedisConfig.java
+++ b/src/main/java/toy/login/commons/config/RedisConfig.java
@@ -1,0 +1,19 @@
+package toy.login.commons.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+// @EnableRedisRepositories
+// @Configuration
+public class RedisConfig {
+
+	/**
+	 * 별도로 선언을 해서 redisConnectionFactory 를 변경할 수 있다.
+	 * 하지만 Spring boot 를 사용하면 별도로 지정하지 않아도 autoConfiguration 에 의해서 등록된다.
+	 */
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory();
+	}
+}

--- a/src/main/java/toy/login/commons/controller/RedisController.java
+++ b/src/main/java/toy/login/commons/controller/RedisController.java
@@ -1,0 +1,28 @@
+package toy.login.commons.controller;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@Slf4j
+@RequestMapping("/redis")
+@RequiredArgsConstructor
+public class RedisController {
+
+	private final RedisTemplate<String, String> redisTemplate;
+
+	@GetMapping
+	public String test() {
+		ValueOperations<String, String> operations = redisTemplate.opsForValue();
+		log.info("redisFactory default autoconfig = {}",
+			redisTemplate.getConnectionFactory().getClass().getSimpleName());
+		operations.set("test", "test");
+		return operations.get("test");
+	}
+}

--- a/src/main/java/toy/login/session/controller/LoginSessionController.java
+++ b/src/main/java/toy/login/session/controller/LoginSessionController.java
@@ -18,7 +18,7 @@ import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import toy.login.session.domain.LoginInfo;
-import toy.login.session.repository.SessionRepository;
+import toy.login.session.repository.LoginSessionRepository;
 import toy.login.session.service.RedisService;
 import toy.login.users.service.UserService;
 
@@ -29,7 +29,7 @@ import toy.login.users.service.UserService;
 public class LoginSessionController {
 
 	private final UserService userService;
-	private final SessionRepository sessionRepository;
+	private final LoginSessionRepository loginSessionRepository;
 	private final RedisService redisService;
 
 	@GetMapping
@@ -46,7 +46,7 @@ public class LoginSessionController {
 		String jSession = session.getId();
 
 		// http 요청 session id 를 value 로 저장하고 key 값을 리턴
-		String sessionId = sessionRepository.createSession(jSession);
+		String sessionId = loginSessionRepository.createSession(jSession);
 
 		// session id 를 찾는 key 값을 cookie 로 전달
 		Cookie sessionIdCookie = new Cookie("mySessionId", sessionId);
@@ -67,7 +67,7 @@ public class LoginSessionController {
 			return new ResponseEntity<>("로그인 먼저 진행해주세요.", HttpStatus.UNAUTHORIZED);
 		}
 
-		Object sessionId = sessionRepository.getSession(mySessionId);
+		Object sessionId = loginSessionRepository.getSession(mySessionId);
 		if (sessionId != null && sessionId.equals(session.getId())) {
 			return new ResponseEntity<>("기 로그인되어 자동 로그인 되었습니다.", HttpStatus.OK);
 		}
@@ -82,7 +82,7 @@ public class LoginSessionController {
 		for (Cookie cookie : cookies) {
 			if (cookie.getName().equals("mySessionId")) {
 				// sesstion 저장소의 정보 제거
-				sessionRepository.removeSession(cookie.getValue());
+				loginSessionRepository.removeSession(cookie.getValue());
 
 				// 클라이언트에 쿠키 정보 제거
 				cookie.setMaxAge(0);

--- a/src/main/java/toy/login/session/controller/LoginSessionController.java
+++ b/src/main/java/toy/login/session/controller/LoginSessionController.java
@@ -1,5 +1,7 @@
 package toy.login.session.controller;
 
+import java.util.UUID;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -7,6 +9,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.SessionAttribute;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -44,35 +47,9 @@ public class LoginSessionController {
 
 		// http 요청 session id 를 value 로 저장하고 key 값을 리턴
 		String sessionId = sessionRepository.createSession(jSession);
+
 		// session id 를 찾는 key 값을 cookie 로 전달
 		Cookie sessionIdCookie = new Cookie("mySessionId", sessionId);
-		sessionIdCookie.setPath("/session");
-		response.addCookie(sessionIdCookie);
-
-		return new ResponseEntity("로그인 되었습니다.", HttpStatus.OK);
-	}
-
-	@GetMapping("/redis")
-	public ResponseEntity redisLogin(@RequestParam("loginId") String loginId,
-		@RequestParam("password") String password,
-		HttpServletRequest request,
-		HttpServletResponse response
-	) {
-		// 파라미터를 제공하지 않으면 ExceptionHandler 에 의해서 400 에러 발생
-		userService.login(loginId, password);
-
-		// jsession 세션 정보 가져오기
-		HttpSession session = request.getSession();
-		String jSession = session.getId();
-
-		// Redis 에 넣을 도메인 객체 생성
-		LoginInfo loginInfo = new LoginInfo(jSession);
-
-		// RedisRepository 를 통해서 등록
-		redisService.save(loginInfo);
-
-		// session id 를 찾는 key 값을 cookie 로 전달
-		Cookie sessionIdCookie = new Cookie("mySessionId", loginInfo.getSessionId());
 		sessionIdCookie.setPath("/session");
 		response.addCookie(sessionIdCookie);
 
@@ -114,6 +91,93 @@ public class LoginSessionController {
 				break;
 			}
 		}
+		return new ResponseEntity("로그아웃 되었습니다.", HttpStatus.OK);
+	}
+
+	@GetMapping("/redis")
+	public ResponseEntity redisLogin(@RequestParam("loginId") String loginId,
+		@RequestParam("password") String password,
+		HttpServletRequest request,
+		HttpServletResponse response
+	) {
+		// 파라미터를 제공하지 않으면 ExceptionHandler 에 의해서 400 에러 발생
+		userService.login(loginId, password);
+
+		// jsession 세션 정보 가져오기
+		HttpSession session = request.getSession();
+		String jSession = session.getId();
+
+		// Redis 에 넣을 도메인 객체 생성
+		// 만료 시간 -1 무제한
+		// LoginInfo loginInfo = new LoginInfo(jSession);
+		// 만료 시간 초 단위로 제공 60초 후 만료
+		LoginInfo loginInfo = new LoginInfo(UUID.randomUUID().toString(), jSession, 60);
+
+		// RedisRepository 를 통해서 등록
+		redisService.save(loginInfo);
+
+		session.setAttribute("mySessionId", loginInfo);
+
+		// session id 를 찾는 key 값을 cookie 로 전달
+		Cookie sessionIdCookie = new Cookie("mySessionId", loginInfo.getSessionId());
+		sessionIdCookie.setPath("/session");
+		response.addCookie(sessionIdCookie);
+
+		return new ResponseEntity("로그인 되었습니다.", HttpStatus.OK);
+	}
+
+	@GetMapping("/redis/check")
+	public ResponseEntity loginRedisCheckV1(HttpServletRequest request,
+		@CookieValue(value = "mySessionId", required = false) String mySessionId,
+		@SessionAttribute(value = "mySessionId", required = false) LoginInfo loginInfo) {
+
+		if (loginInfo != null) {
+			log.info("{} : {}", loginInfo.getSessionId(), loginInfo.getJSessionId());
+		}
+		HttpSession session = request.getSession(false);
+		LoginInfo loginInfoSession = (LoginInfo)session.getAttribute("mySessionId");
+
+		log.info(" loginInfoSession == loginInfo : {}", loginInfoSession.equals(loginInfo));
+
+		// Cookie 에서 Redis Key 값 확인
+		if (mySessionId != null) {
+			LoginInfo sessionId = redisService.findSessionId(mySessionId);
+			if (sessionId == null) {
+				return new ResponseEntity<>("로그인 만료 재 로그인 해주세요.", HttpStatus.NOT_ACCEPTABLE);
+			}
+
+			return new ResponseEntity<>("기 로그인되어 자동 로그인 되었습니다.", HttpStatus.OK);
+		}
+
+		return new ResponseEntity<>("로그인 먼저 진행해주세요.", HttpStatus.UNAUTHORIZED);
+	}
+
+	@GetMapping("/redis/logout")
+	public ResponseEntity redisLogout(@CookieValue(value = "mySessionId", required = false) String mySessionId,
+		@SessionAttribute(value = "mySessionId", required = false) LoginInfo loginInfo,
+		HttpServletRequest request,
+		HttpServletResponse response
+	) {
+
+		// 쿠키 제거
+		if (mySessionId != null) {
+			Cookie cookie = new Cookie("mySessionId", null);
+			cookie.setPath("/session");
+			cookie.setMaxAge(0);
+			response.addCookie(cookie);
+		}
+
+		// redis 저장소 제거
+		if (loginInfo != null) {
+			redisService.delete(loginInfo);
+		}
+
+		// 세션 정보 제거
+		HttpSession requestSession = request.getSession(false);
+		if (requestSession != null) {
+			requestSession.invalidate();
+		}
+
 		return new ResponseEntity("로그아웃 되었습니다.", HttpStatus.OK);
 	}
 

--- a/src/main/java/toy/login/session/controller/LoginSessionRedisTemplateController.java
+++ b/src/main/java/toy/login/session/controller/LoginSessionRedisTemplateController.java
@@ -1,0 +1,42 @@
+package toy.login.session.controller;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import toy.login.users.service.UserService;
+
+@RestController
+@Slf4j
+@RequestMapping("/session/template")
+@RequiredArgsConstructor
+public class LoginSessionRedisTemplateController {
+
+	private final RedisTemplate<String, String> redisTemplate;
+	private final UserService userService;
+
+	@GetMapping("/login")
+	public ResponseEntity login(@RequestParam String loginId,
+		@RequestParam String password,
+		HttpServletRequest request
+	) {
+
+		userService.login(loginId, password);
+
+		HttpSession session = request.getSession();
+
+		ValueOperations<String, String> operations = redisTemplate.opsForValue();
+		operations.set(session.getId(), "mySessionId");
+
+		return new ResponseEntity("로그인 되었습니다.", HttpStatus.OK);
+	}
+}

--- a/src/main/java/toy/login/session/controller/LoginSessionRedisTemplateController.java
+++ b/src/main/java/toy/login/session/controller/LoginSessionRedisTemplateController.java
@@ -39,4 +39,18 @@ public class LoginSessionRedisTemplateController {
 
 		return new ResponseEntity("로그인 되었습니다.", HttpStatus.OK);
 	}
+
+	@GetMapping("/check")
+	public ResponseEntity check(HttpServletRequest request) {
+		HttpSession session = request.getSession(false);
+		if (session != null) {
+			String id = session.getId();
+			ValueOperations<String, String> operations = redisTemplate.opsForValue();
+			String s = operations.get(id);
+			if (s.equals("mySessionId")) {
+				return new ResponseEntity<>("기 로그인되어 자동 로그인 되었습니다.", HttpStatus.OK);
+			}
+		}
+		return new ResponseEntity<>("로그인 먼저 진행해주세요.", HttpStatus.UNAUTHORIZED);
+	}
 }

--- a/src/main/java/toy/login/session/controller/LoginSessionRedisTemplateController.java
+++ b/src/main/java/toy/login/session/controller/LoginSessionRedisTemplateController.java
@@ -1,5 +1,7 @@
 package toy.login.session.controller;
 
+import java.time.Duration;
+
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.http.HttpStatus;
@@ -50,6 +52,22 @@ public class LoginSessionRedisTemplateController {
 			if (s.equals("mySessionId")) {
 				return new ResponseEntity<>("기 로그인되어 자동 로그인 되었습니다.", HttpStatus.OK);
 			}
+		}
+		return new ResponseEntity<>("로그인 먼저 진행해주세요.", HttpStatus.UNAUTHORIZED);
+	}
+
+	@GetMapping("/logout")
+	public ResponseEntity logout(HttpServletRequest request) {
+		HttpSession session = request.getSession(false);
+		if (session != null) {
+			String id = session.getId();
+
+			// 매개변수 key 와 일치하는 데이터 삭제
+			redisTemplate.delete(id);
+			// 등록된 Key 에 대해서 만료시간 지정 0 으로 지정 시 redis 에서 삭제 처리
+			redisTemplate.expire(id, Duration.ZERO);
+
+			return new ResponseEntity("로그아웃 되었습니다.", HttpStatus.OK);
 		}
 		return new ResponseEntity<>("로그인 먼저 진행해주세요.", HttpStatus.UNAUTHORIZED);
 	}

--- a/src/main/java/toy/login/session/controller/LoginSpringSessionController.java
+++ b/src/main/java/toy/login/session/controller/LoginSpringSessionController.java
@@ -1,0 +1,21 @@
+package toy.login.session.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/springsession")
+public class LoginSpringSessionController {
+
+	@GetMapping
+	public void createSession(HttpServletRequest request, HttpServletResponse response) {
+		HttpSession session = request.getSession();
+	}
+}

--- a/src/main/java/toy/login/session/controller/LoginSpringSessionController.java
+++ b/src/main/java/toy/login/session/controller/LoginSpringSessionController.java
@@ -1,21 +1,57 @@
 package toy.login.session.controller;
 
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import toy.login.users.service.UserService;
 
 @Slf4j
 @RestController
 @RequestMapping("/springsession")
+@RequiredArgsConstructor
 public class LoginSpringSessionController {
+
+	private final UserService userService;
 
 	@GetMapping
 	public void createSession(HttpServletRequest request, HttpServletResponse response) {
 		HttpSession session = request.getSession();
+	}
+
+	@GetMapping("/login")
+	public void getSession(@RequestParam("loginId") String loginId,
+		@RequestParam("password") String password,
+		HttpServletRequest request,
+		@CookieValue("toyLoginSession") String cookieName) {
+
+		// 파라미터를 제공하지 않으면 ExceptionHandler 에 의해서 400 에러 발생
+		userService.login(loginId, password);
+
+		HttpSession session = request.getSession();
+		log.info("session id = {}", session.getId());
+		log.info("seesion cookie = {}", cookieName);
+
+		session.setAttribute("toyLoginSession", loginId);
+
+	}
+
+	@GetMapping("/check")
+	public void check(HttpServletRequest request) {
+		HttpSession session = request.getSession(false);
+		if (session != null) {
+			log.info("session Id = {}", session.getId());
+			log.info("session value = {}", session.getAttribute("toyLoginSession"));
+		} else {
+			log.info("session null");
+		}
+
 	}
 }

--- a/src/main/java/toy/login/session/domain/LoginInfo.java
+++ b/src/main/java/toy/login/session/domain/LoginInfo.java
@@ -1,0 +1,33 @@
+package toy.login.session.domain;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@RedisHash(value = "loginInfo")
+@Getter
+@Setter
+public class LoginInfo {
+
+	@Id
+	private String sessionId;
+
+	@Indexed
+	private String jSessionId;
+
+	@TimeToLive
+	private long ttl;
+
+	public LoginInfo(String jSessionId) {
+		this.jSessionId = jSessionId;
+	}
+
+	public LoginInfo(String jSessionId, long ttl) {
+		this.jSessionId = jSessionId;
+		this.ttl = ttl;
+	}
+}

--- a/src/main/java/toy/login/session/domain/LoginInfo.java
+++ b/src/main/java/toy/login/session/domain/LoginInfo.java
@@ -5,12 +5,15 @@ import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 import org.springframework.data.redis.core.index.Indexed;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @RedisHash(value = "loginInfo")
 @Getter
 @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LoginInfo {
 
 	@Id
@@ -27,6 +30,12 @@ public class LoginInfo {
 	}
 
 	public LoginInfo(String jSessionId, long ttl) {
+		this.jSessionId = jSessionId;
+		this.ttl = ttl;
+	}
+
+	public LoginInfo(String sessionId, String jSessionId, long ttl) {
+		this.sessionId = sessionId;
 		this.jSessionId = jSessionId;
 		this.ttl = ttl;
 	}

--- a/src/main/java/toy/login/session/interceptor/LoginSessionCheckInterceptor.java
+++ b/src/main/java/toy/login/session/interceptor/LoginSessionCheckInterceptor.java
@@ -8,13 +8,13 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import toy.login.session.repository.SessionRepository;
+import toy.login.session.repository.LoginSessionRepository;
 
 @RequiredArgsConstructor
 @Slf4j
 public class LoginSessionCheckInterceptor implements HandlerInterceptor {
 
-	private final SessionRepository sessionRepository;
+	private final LoginSessionRepository loginSessionRepository;
 
 	@Override
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws
@@ -29,7 +29,7 @@ public class LoginSessionCheckInterceptor implements HandlerInterceptor {
 			}
 		}
 
-		Object sessionId = sessionRepository.getSession(mySessionId);
+		Object sessionId = loginSessionRepository.getSession(mySessionId);
 		HttpSession session = request.getSession(false);
 		if (session == null || sessionId == null) {
 			return false;

--- a/src/main/java/toy/login/session/repository/LoginInfoRedisRepository.java
+++ b/src/main/java/toy/login/session/repository/LoginInfoRedisRepository.java
@@ -1,0 +1,9 @@
+package toy.login.session.repository;
+
+import org.springframework.data.repository.CrudRepository;
+
+import toy.login.session.domain.LoginInfo;
+
+public interface LoginInfoRedisRepository extends CrudRepository<LoginInfo, String> {
+
+}

--- a/src/main/java/toy/login/session/repository/LoginSessionRepository.java
+++ b/src/main/java/toy/login/session/repository/LoginSessionRepository.java
@@ -7,7 +7,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public class SessionRepository {
+public class LoginSessionRepository {
 
 	private static final Map<String, Object> STORAGE = new ConcurrentHashMap<>();
 

--- a/src/main/java/toy/login/session/service/RedisService.java
+++ b/src/main/java/toy/login/session/service/RedisService.java
@@ -1,0 +1,30 @@
+package toy.login.session.service;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import toy.login.session.domain.LoginInfo;
+import toy.login.session.repository.LoginInfoRedisRepository;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+	private final LoginInfoRedisRepository loginInfoRedisRepository;
+
+	public void save(LoginInfo loginInfo) {
+		
+		// loginInfo 저장
+		loginInfoRedisRepository.save(loginInfo);
+
+		// keyspace:id 의 값을 찾는다.
+		// loginInfoRedisRepository.findById(save.getSessionId());
+
+		// Entity 에 정의되어 있는 @RedisHash 에 정의되어 있는 keyspace 에 속하는 키의 갯수를 구합니다.
+		// loginInfoRedisRepository.count();
+
+		// 삭제
+		// loginInfoRedisRepository.delete(save);
+	}
+
+}

--- a/src/main/java/toy/login/session/service/RedisService.java
+++ b/src/main/java/toy/login/session/service/RedisService.java
@@ -3,28 +3,38 @@ package toy.login.session.service;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import toy.login.session.domain.LoginInfo;
 import toy.login.session.repository.LoginInfoRedisRepository;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class RedisService {
 
 	private final LoginInfoRedisRepository loginInfoRedisRepository;
 
 	public void save(LoginInfo loginInfo) {
-		
+
 		// loginInfo 저장
 		loginInfoRedisRepository.save(loginInfo);
 
 		// keyspace:id 의 값을 찾는다.
-		// loginInfoRedisRepository.findById(save.getSessionId());
+		// loginInfoRedisRepository.findById(loginInfo.getSessionId());
 
 		// Entity 에 정의되어 있는 @RedisHash 에 정의되어 있는 keyspace 에 속하는 키의 갯수를 구합니다.
 		// loginInfoRedisRepository.count();
 
 		// 삭제
 		// loginInfoRedisRepository.delete(save);
+	}
+
+	public LoginInfo findSessionId(String sessionId) {
+		return loginInfoRedisRepository.findById(sessionId).orElse(null);
+	}
+
+	public void delete(LoginInfo loginInfo) {
+		loginInfoRedisRepository.delete(loginInfo);
 	}
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,9 @@ spring:
     redis:
       host: localhost
       port: 6379
+  session:
+    redis:
+      namespace: toy:session
 
 logging:
   level:
@@ -27,4 +30,9 @@ management:
     web:
       exposure:
         include: "*"
-
+server:
+  servlet:
+    session:
+      cookie:
+        name: toyLoginSession
+      timeout: 10

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,4 +35,3 @@ server:
     session:
       cookie:
         name: toyLoginSession
-      timeout: 10

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,10 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.H2Dialect
     database-platform: org.hibernate.dialect.H2Dialect
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 logging:
   level:


### PR DESCRIPTION
## Session 불일치 현상을 해결
- 외부 저장소인 Redis 를 사용하여 Session ID 와 로그인 정보를 저장
  - Repository
  - RedisTemplate 
- 위 2가지 방식을 각각 적용

## Spring Session
- 기존의 Spring boot 로 진행하는 경우 Session 정보가 내장 WAS 인 Tomcat 에 의해 생성되며 in - memory 로 저장되는 방식을 Spring session 을 통해서 외부 저장소 Redis 자체에 Session 정보를 저장할 수 있도로 변경